### PR TITLE
Add compiler flag to compile on Debian Trixie

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 """Instructions for setuptools to build the rrdtool bindings."""
 
 import os
+import platform
 import subprocess
+import sys
 
 from setuptools import Extension, setup
 
@@ -9,12 +11,27 @@ from setuptools import Extension, setup
 if subprocess.run(["command -v gcc-11"], shell=True, check=False).returncode > 0:
     os.environ["CC"] = "gcc"
 
+extra_compile_args = []
+
+# Debian Trixie: disable incompatible-pointer-types
+if sys.version_info >= (3, 10):
+    distro_info = platform.freedesktop_os_release()
+    if distro_info["ID"] == "debian" and distro_info["VERSION_ID"] == "13":
+        extra_compile_args.append("-Wno-incompatible-pointer-types")
+elif not subprocess.run(
+    ["/usr/bin/grep", "13", "/etc/debian_version"], check=False
+).returncode:
+    extra_compile_args.append("-Wno-incompatible-pointer-types")
+
+print("Extra compile args:", extra_compile_args)
+
 setup(
     ext_modules=[
         Extension(
             name="rrdtool",
             sources=["src/rrdtool/rrdtoolmodule.c"],
             libraries=["rrd"],
+            extra_compile_args=extra_compile_args,
         )
     ]
 )


### PR DESCRIPTION
Debian 13 (Trixie) still has RRDtool 1.7.2 which doesn't include the fix from RRDtool 1.9 to address pointer type mismatches. Therefore, we need to build with `-Wno-incompatible-pointer-types`.

Ideally we could just use `platform.freedesktop_os_release()` to read `/etc/os-release`, but it was added in Python 3.10 and we still support Python 3.9.

I need to do some testing to see if the Fedora "fix" is still required or not.

Fixes #4 