### PR TITLE
make compatible with MacOS (and maybe also Windows)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = []
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -7,21 +7,28 @@ import sys
 
 from setuptools import Extension, setup
 
-# on Fedora it wanted `gcc-11`, which didn't exist
-if subprocess.run(["command -v gcc-11"], shell=True, check=False).returncode > 0:
-    os.environ["CC"] = "gcc"
-
 extra_compile_args = []
 
-# Debian Trixie: disable incompatible-pointer-types
-if sys.version_info >= (3, 10):
-    distro_info = platform.freedesktop_os_release()
-    if distro_info["ID"] == "debian" and distro_info["VERSION_ID"] == "13":
-        extra_compile_args.append("-Wno-incompatible-pointer-types")
-elif not subprocess.run(
-    ["/usr/bin/grep", "13", "/etc/debian_version"], check=False
-).returncode:
+# with most newer compilers, "-Wno-incompatible-pointer-types" is needed to suppress warnings that are due to a 'const' mismatch with the rrdtool C API
+# TODO: why not make it depend on the compiler version instead of the platform/version?
+
+if sys.platform == "darwin":
+    # macOS: disable incompatible-pointer-types
     extra_compile_args.append("-Wno-incompatible-pointer-types")
+elif sys.platform.startswith("linux"):
+    # on Fedora it wanted `gcc-11`, which didn't exist
+    if subprocess.run(["command -v gcc-11"], shell=True, check=False).returncode > 0:
+        os.environ["CC"] = "gcc"
+
+    # Debian Trixie: disable incompatible-pointer-types
+    if sys.version_info >= (3, 10):
+        distro_info = platform.freedesktop_os_release()
+        if distro_info["ID"] == "debian" and distro_info["VERSION_ID"] == "13":
+            extra_compile_args.append("-Wno-incompatible-pointer-types")
+    elif not subprocess.run(
+        ["/usr/bin/grep", "13", "/etc/debian_version"], check=False
+    ).returncode:
+        extra_compile_args.append("-Wno-incompatible-pointer-types")
 
 print("Extra compile args:", extra_compile_args)
 


### PR DESCRIPTION
The setup used a couple of constructs that are not valid outside Linux.
This change allows installation on MacOS, and likely also other platforms like Windows.
And validated that Python 3.14 works.